### PR TITLE
Fixed leak of dynamically-allocated data.

### DIFF
--- a/src/runtime/Classes/PBArray.m
+++ b/src/runtime/Classes/PBArray.m
@@ -149,6 +149,13 @@ static PBArrayValueTypeInfo PBValueTypes[] =
 	return copy;
 }
 
+- (void)dealloc
+{
+    if (_data)
+    {
+        free(_data);
+    }
+}
 
 - (NSString *)description
 {


### PR DESCRIPTION
In PBArray.m, in the implementation of PBAppendableArray, the -dealloc method was removed a while back.  That -dealloc method freed the _data memory (which was dynamically malloc()'d in the initializer and possibly reallocf()'d in the -ensureAdditionalCapacity: method), and that memory is no longer freed and thus leaked.
