### PR TITLE
add function converting enum to nsstring , make enum field description clearer...

### DIFF
--- a/src/compiler/objc_enum.cc
+++ b/src/compiler/objc_enum.cc
@@ -71,6 +71,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "};\n"
                        "\n"
                        "BOOL $classname$IsValidValue($classname$ value);\n"
+                       "NSString *NSStringFrom$classname$($classname$ value);\n"
                        "\n",
                        "classname", ClassName(descriptor_));
     }
@@ -94,6 +95,23 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "      return NO;\n"
                        "  }\n"
                        "}\n");
+        printer->Print(
+                       "NSString *NSStringFrom$classname$($classname$ value) {\n"
+                       "  switch (value) {\n",
+                       "classname", ClassName(descriptor_));
+        
+        for (int i = 0; i < canonical_values_.size(); i++) {
+            printer->Print(
+                           "    case $name$:\n"
+                           "      return @\"$name$\";\n",
+                           "name", EnumValueName(canonical_values_[i]));
+        }
+        
+        printer->Print(
+                       "    default:\n"
+                       "      return nil;\n"
+                       "  }\n"
+                       "}\n\n");
     }
 }  // namespace objectivec
 }  // namespace compiler

--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -203,7 +203,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     void EnumFieldGenerator::GenerateDescriptionCodeSource(io::Printer* printer) const {
         printer->Print(variables_,
                        "if (self.has$capitalized_name$) {\n"
-                       "  [output appendFormat:@\"%@%@: %@\\n\", indent, @\"$name$\", [NSNumber numberWithInteger:self.$name$]];\n"
+                       "  [output appendFormat:@\"%@%@: %@\\n\", indent, @\"$name$\", NSStringFrom$type$(self.$name$)];\n"
                        "}\n");
     }
     
@@ -453,7 +453,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     void RepeatedEnumFieldGenerator::GenerateDescriptionCodeSource(io::Printer* printer) const {
         printer->Print(variables_,
                        "[self.$list_name$ enumerateObjectsUsingBlock:^(id element, NSUInteger idx, BOOL *stop) {\n"
-                       "  [output appendFormat:@\"%@%@: %@\\n\", indent, @\"$name$\", element];\n"
+                       "  [output appendFormat:@\"%@%@: %@\\n\", indent, @\"$name$\", NSStringFrom$type$([(NSNumber *)element intValue])];\n"
                        "}];\n");
     }
     


### PR DESCRIPTION
add function from enum to nsstring , make enum field description clearer.
when object is called  -[ description] method, enum will be print as a integer. 
so I add a function converting enum to nsstring, enum field can be print clearer.

Signed-off-by: Jun <tobefuturer@gmail.com>