### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ How To Install Protobuf
 
 7. `cd <your .xcodeproj directory>`
 
-8. `echo -e "platform :ios , 6.0 \nlink_with '<YourAppTarget>', '<YourAppTarget_Test>' \npod 'ProtocolBuffers', '1.9.6' " > Podfile`
+8. `echo -e "platform :ios , 6.0 \nlink_with '<YourAppTarget>', '<YourAppTarget_Test>' \npod 'ProtocolBuffers', '1.9.7' " > Podfile`
 
 9. `pod install`
 


### PR DESCRIPTION
Right now generated message classes (compiled with protoc --plugin=/usr/local/bin/protoc-gen-objc person.proto --objc_out="./" directive) conform to GeneratedMessageProtocol, but this protocol is not available in ver. 1.9.6.
Changing version to 1.9.7 fixes that issue.