### PR TITLE
Add the ability to store a PBMessage into an NSMutableDictionary.

### DIFF
--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -207,7 +207,14 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "  [output appendFormat:@\"%@%@: %@\\n\", indent, @\"$name$\", NSStringFrom$type$(self.$name$)];\n"
                        "}\n");
     }
-    
+
+    void EnumFieldGenerator::GenerateDictionaryCodeSource(io::Printer* printer) const {
+        printer->Print(variables_,
+                       "if (self.has$capitalized_name$) {\n"
+                       "  [dictionary setObject: @(self.$name$) forKey: @\"$name$\"];\n"
+                       "}\n");
+  }
+
     
     void EnumFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
         printer->Print(variables_,
@@ -458,6 +465,21 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "}];\n");
     }
     
+    void RepeatedEnumFieldGenerator::GenerateDictionaryCodeSource(io::Printer* printer) const {
+      printer->Print(variables_,
+                     "const NSUInteger $list_name$Count = self.$list_name$.count;\n"
+                     "if ($list_name$Count > 0) {\n"
+                     "  const $type$ *$list_name$Values = (const $type$ *)self.$list_name$.data;\n");
+      printer->Indent();
+      printer->Print(variables_,
+                     "NSMutableArray * $list_name$Array = [NSMutableArray new];\n"
+                     "for (NSUInteger i = 0; i < $list_name$Count; ++i) {\n"
+                     "  [$list_name$Array addObject: @($list_name$Values[i])];\n"
+                     "}\n"
+                     "[dictionary setObject: $list_name$Array forKey: @\"$name$\"];\n");
+      printer->Outdent();
+      printer->Print("}\n");
+    }
     
     void RepeatedEnumFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
         printer->Print(variables_, "[self.$list_name$ isEqualToArray:otherMessage.$list_name$] &&");

--- a/src/compiler/objc_enum_field.h
+++ b/src/compiler/objc_enum_field.h
@@ -56,6 +56,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer* printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     
@@ -96,6 +97,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer* printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     

--- a/src/compiler/objc_field.h
+++ b/src/compiler/objc_field.h
@@ -61,6 +61,7 @@ namespace google {
                     virtual void GenerateSerializationCodeSource(io::Printer* printer) const = 0;
                     virtual void GenerateSerializedSizeCodeSource(io::Printer* printer) const = 0;
                     virtual void GenerateDescriptionCodeSource(io::Printer* printer) const = 0;
+                    virtual void GenerateDictionaryCodeSource(io::Printer* printer) const = 0;
                     virtual void GenerateIsEqualCodeSource(io::Printer* printer) const = 0;
                     virtual void GenerateHashCodeSource(io::Printer* printer) const = 0;
                     

--- a/src/compiler/objc_message.h
+++ b/src/compiler/objc_message.h
@@ -76,6 +76,12 @@ namespace google {
                     void GenerateDescriptionOneExtensionRangeSource(
                                                                     io::Printer* printer, const Descriptor::ExtensionRange* range);
                     
+                    void GenerateMessageDictionarySource(io::Printer *printer);
+                    void GenerateDictionaryOneFieldSource(io::Printer *printer,
+                                                          const FieldDescriptor* field);
+                    void GenerateDictionaryOneExtensionRangeSource(io::Printer *printer,
+                                                                    const Descriptor::ExtensionRange *range);
+
                     void GenerateMessageIsEqualSource(io::Printer* printer);
                     void GenerateIsEqualOneFieldSource(io::Printer* printer,
                                                        const FieldDescriptor* field);

--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -243,7 +243,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     		"if (self.has$capitalized_name$) {\n"
     		" NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; \n"
     		" [self.$name$ storeInDictionary:messageDictionary];\n"
-    		" [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@\"$name\"];\n"
+    		" [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@\"$name$\"];\n"
     		"}\n");
     }
     

--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -237,6 +237,15 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "  [output appendFormat:@\"%@}\\n\", indent];\n"
                        "}\n");
     }
+
+    void MessageFieldGenerator::GenerateDictionaryCodeSource(io::Printer *printer) const {
+    	printer->Print(variables_,
+    		"if (self.has$capitalized_name$) {\n"
+    		" NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; \n"
+    		" [self.$name$ storeInDictionary:messageDictionary];\n"
+    		" [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@\"$name\"];\n"
+    		"}\n");
+    }
     
     
     void MessageFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
@@ -462,6 +471,16 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "  [output appendFormat:@\"%@}\\n\", indent];\n"
                        "}];\n");
     }
+
+  	void RepeatedMessageFieldGenerator::GenerateDictionaryCodeSource(io::Printer* printer) const {
+    	printer->Print(variables_,
+      				   "for ($type$* element in self.$list_name$) {\n"
+      				   "  NSMutableDictionary *elementDictionary = [NSMutableDictionary dictionary];\n"
+      				   "  [element storeInDictionary:elementDictionary];\n"
+      				   "  [dictionary setObject:[NSDictionary dictionaryWithDictionary:elementDictionary] forKey:@\"$name$\"];\n"
+      				   "}\n");
+	}
+
     
     void RepeatedMessageFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
         printer->Print(variables_, "[self.$list_name$ isEqualToArray:otherMessage.$list_name$] &&");

--- a/src/compiler/objc_message_field.h
+++ b/src/compiler/objc_message_field.h
@@ -56,6 +56,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer* printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     
@@ -96,6 +97,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer *printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     

--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -396,6 +396,17 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "];\n"
                        "}\n");
     }
+
+    void PrimitiveFieldGenerator::GenerateDictionaryCodeSource(io::Printer* printer) const {
+        printer->Print(variables_,
+                       "if (self.has$capitalized_name$) {\n"
+                       "  [dictionary setObject: ");
+        printer->Print(variables_,
+                       BoxValue(descriptor_, "self.$name$").c_str());//RAGY
+        printer->Print(variables_,
+                       " forKey: @\"$name$\"];\n"
+                       "}\n");
+    }
     
     void PrimitiveFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
         printer->Print(variables_,
@@ -760,6 +771,21 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "}];\n");
     }
     
+    void RepeatedPrimitiveFieldGenerator::GenerateDictionaryCodeSource(io::Printer* printer) const {
+        if (ReturnsPrimitiveType(descriptor_)) {
+            printer->Print(variables_,
+                           "NSMutableArray * $list_name$Array = [NSMutableArray new];\n"
+                           "NSUInteger $list_name$Count=self.$list_name$.count;\n"
+                           "for(int i=0;i<$list_name$Count;i++){\n"
+                           "  [$list_name$Array addObject: @([self.$list_name$ $array_value_type_name$AtIndex:i]) forKey: @\"$name$\"];\n"
+                           "}\n"
+                           "[dictionary setObject: $list_name$Array forKey: @\"$name$\"];\n");
+        } else {
+            printer->Print(variables_,
+                           "[dictionary setObject:self.$name$ forKey: @\"$name$\"];\n");
+        }
+    }
+
     
     void RepeatedPrimitiveFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
         printer->Print(variables_,

--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -777,7 +777,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                            "NSMutableArray * $list_name$Array = [NSMutableArray new];\n"
                            "NSUInteger $list_name$Count=self.$list_name$.count;\n"
                            "for(int i=0;i<$list_name$Count;i++){\n"
-                           "  [$list_name$Array addObject: @([self.$list_name$ $array_value_type_name$AtIndex:i]) forKey: @\"$name$\"];\n"
+                           "  [$list_name$Array addObject: @([self.$list_name$ $array_value_type_name$AtIndex:i])];\n"
                            "}\n"
                            "[dictionary setObject: $list_name$Array forKey: @\"$name$\"];\n");
         } else {

--- a/src/compiler/objc_primitive_field.h
+++ b/src/compiler/objc_primitive_field.h
@@ -56,6 +56,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer* printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     
@@ -94,6 +95,7 @@ namespace google {
                     void GenerateSerializationCodeSource(io::Printer* printer) const;
                     void GenerateSerializedSizeCodeSource(io::Printer* printer) const;
                     void GenerateDescriptionCodeSource(io::Printer* printer) const;
+                    void GenerateDictionaryCodeSource(io::Printer* printer) const;
                     void GenerateIsEqualCodeSource(io::Printer* printer) const;
                     void GenerateHashCodeSource(io::Printer* printer) const;
                     

--- a/src/runtime/Classes/AbstractMessage.h
+++ b/src/runtime/Classes/AbstractMessage.h
@@ -34,4 +34,6 @@
 - (void)writeDescriptionTo:(NSMutableString*) output
                 withIndent:(NSString*) indent;
 
+- (void) storeInDictionary: (NSMutableDictionary *) dic;
+
 @end

--- a/src/runtime/Classes/AbstractMessage.m
+++ b/src/runtime/Classes/AbstractMessage.m
@@ -91,5 +91,13 @@
   return output;
 }
 
+- (void) storeInDictionary: (NSMutableDictionary *) dic {
+  @throw [NSException exceptionWithName:@"ImproperSubclassing" reason:@"" userInfo:nil];
+}
+
+- (NSDictionary *) dictionaryRepresentation {
+  @throw [NSException exceptionWithName:@"ImproperSubclassing" reason:@"" userInfo:nil];
+}
+
 
 @end

--- a/src/runtime/Classes/ConcreteExtensionField.m
+++ b/src/runtime/Classes/ConcreteExtensionField.m
@@ -450,6 +450,49 @@ SInt32 typeSize(PBExtensionType type) {
   }
 }
 
+- (id) dictionaryObjectValueForObject: (id) object {
+    switch (type) {
+        case PBExtensionTypeBool:
+        case PBExtensionTypeFixed32:
+        case PBExtensionTypeSFixed32:
+        case PBExtensionTypeFloat:
+        case PBExtensionTypeFixed64:
+        case PBExtensionTypeSFixed64:
+        case PBExtensionTypeDouble:
+        case PBExtensionTypeInt32:
+        case PBExtensionTypeInt64:
+        case PBExtensionTypeSInt32:
+        case PBExtensionTypeSInt64:
+        case PBExtensionTypeUInt32:
+        case PBExtensionTypeUInt64:
+        case PBExtensionTypeBytes:
+        case PBExtensionTypeString:
+        case PBExtensionTypeEnum:
+            return object;
+        case PBExtensionTypeGroup:
+        case PBExtensionTypeMessage:
+        {
+            NSMutableDictionary * dic = [NSMutableDictionary new];
+            [((PBAbstractMessage *)object) storeInDictionary:dic];
+            return dic;
+        }
+    }
+}
+
+- (void) addDictionaryEntriesOf:(id) value
+                             to:(NSMutableDictionary*) dictionary {
+    if (isRepeated) {
+        NSArray* values = value;
+        NSMutableArray * arr = [NSMutableArray new];
+        for (id singleValue in values) {
+            [arr addObject: [self dictionaryObjectValueForObject:singleValue]];
+        }
+        [dictionary setObject: arr forKey: NSStringFromClass([self extendedClass])];
+    } else {
+        [dictionary setObject: [self dictionaryObjectValueForObject:value] forKey: NSStringFromClass([self extendedClass])];
+    }
+}
+
 - (void) mergeMessageSetExtentionFromCodedInputStream:(PBCodedInputStream*) input
                                         unknownFields:(PBUnknownFieldSetBuilder*) unknownFields {
   @throw [NSException exceptionWithName:@"NYI" reason:@"" userInfo:nil];

--- a/src/runtime/Classes/ExtendableMessage.h
+++ b/src/runtime/Classes/ExtendableMessage.h
@@ -76,6 +76,9 @@
                                              from:(SInt32) startInclusive
                                                to:(SInt32) endExclusive
                                        withIndent:(NSString*) indent;
+- (void) addExtensionDictionaryEntriesToMutableDictionary:(NSMutableDictionary*) output
+                                                     from:(int32_t) startInclusive
+                                                       to:(int32_t) endExclusive;
 - (BOOL) isEqualExtensionsInOther:(PBExtendableMessage*)otherMessage
                              from:(SInt32) startInclusive
                                to:(SInt32) endExclusive;

--- a/src/runtime/Classes/ExtendableMessage.m
+++ b/src/runtime/Classes/ExtendableMessage.m
@@ -107,6 +107,19 @@
   }  
 }
 
+- (void) addExtensionDictionaryEntriesToMutableDictionary:(NSMutableDictionary*) output
+                                            from:(int32_t) startInclusive
+                                              to:(int32_t) endExclusive {
+  NSArray* sortedKeys = [extensionMap.allKeys sortedArrayUsingSelector:@selector(compare:)];
+  for (NSNumber* number in sortedKeys) {
+    int32_t fieldNumber = [number intValue];
+    if (fieldNumber >= startInclusive && fieldNumber < endExclusive) {
+      id<PBExtensionField> extension = [extensionRegistry objectForKey:number];
+      id value = [extensionMap objectForKey:number];
+      [extension addDictionaryEntriesOf:value to:output];
+    }
+  }  
+}
 
 - (BOOL) isEqualExtensionsInOther:(PBExtendableMessage*)otherMessage
                              from:(SInt32) startInclusive

--- a/src/runtime/Classes/ExtensionField.h
+++ b/src/runtime/Classes/ExtensionField.h
@@ -40,4 +40,6 @@
 - (void) writeDescriptionOf:(id) value
                          to:(NSMutableString*) output
                  withIndent:(NSString*) indent;
+- (void) addDictionaryEntriesOf:(id) value
+                             to:(NSMutableDictionary*) dictionary;
 @end

--- a/src/runtime/Classes/UnknownFieldSet.h
+++ b/src/runtime/Classes/UnknownFieldSet.h
@@ -47,4 +47,6 @@
 - (void) writeDescriptionTo:(NSMutableString*) output
                  withIndent:(NSString*) indent;
 
+- (void) storeInDictionary: (NSMutableDictionary *) dic;
+
 @end

--- a/src/runtime/Classes/UnknownFieldSet.m
+++ b/src/runtime/Classes/UnknownFieldSet.m
@@ -98,6 +98,10 @@ static PBUnknownFieldSet* defaultInstance = nil;
   }
 }
 
+- (void) storeInDictionary: (NSMutableDictionary *) dic;
+{
+    //TODO: Ignore unknown field sets for now :D
+}
 
 + (PBUnknownFieldSet*) parseFromCodedInputStream:(PBCodedInputStream*) input {
   return [[[PBUnknownFieldSet builder] mergeFromCodedInputStream:input] build];


### PR DESCRIPTION
This adds functionality to make it trivial to turn a PBMessage into a dictionary, storing all known fields with their field name as the key and their closest Objective-C object equivalent as the value.  Simply call storeInDictionary with an NSMutableDictionary, and everything is good.  Nested messages are handled as secondary NSDictionaries, and repeated fields are handled as NSArrays.

I find this useful for my own use, both for fast enumeration situations and (more relevantly) to be able to pass nested data from a protocol buffer into code that does not actually import the Protocol Buffer headers.  So, I offer it here, cherry-picked clean against your current master branch. :)